### PR TITLE
Added support for cross-compiling Ikemen-go-plus using Docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,28 @@
 #!/bin/sh
 export GOPATH=$PWD/go
-CGO_ENABLED=1 go build -o Ikemen_GO ./src
+export CGO_ENABLED=1
+if [ -n "$OS" ];    then 
+    case "$OS" in
+    "windows")
+        export GOOS=windows
+        export CC=x86_64-w64-mingw32-gcc
+        export CXX=x86_64-w64-mingw32-g++
+        BINARY_NAME="Ikemen_GO.exe"; 
+
+        ;;
+    "mac") 
+        export GOOS=darwin
+        export CC=o64-clang 
+        export CXX=o64-clang++
+        BINARY_NAME="Ikemen_GO_mac"; 
+
+        ;;
+    "linux") 
+        BINARY_NAME="Ikemen_GO_linux"; 
+        ;;
+    esac 
+else 
+    BINARY_NAME="Ikemen_GO";  
+fi;
+
+go build -o $BINARY_NAME ./src

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,6 +1,0 @@
-docker run --rm -e OS=linux -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash get.sh' 
-docker run --rm -e OS=linux -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash build.sh' 
-docker run --rm -e OS=windows -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash get.sh' 
-docker run --rm -e OS=windows -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash build.sh' 
-docker run --rm -e OS=mac -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash get.sh' 
-docker run --rm -e OS=mac -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash build.sh' 

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,0 +1,6 @@
+docker run --rm -e OS=linux -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash get.sh' 
+docker run --rm -e OS=linux -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash build.sh' 
+docker run --rm -e OS=windows -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash get.sh' 
+docker run --rm -e OS=windows -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash build.sh' 
+docker run --rm -e OS=mac -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash get.sh' 
+docker run --rm -e OS=mac -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash build.sh' 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,11 @@
+echo "Building linux binary..."
+docker run --rm -e OS=linux -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash -x get.sh' 
+docker run --rm -e OS=linux -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash -x build.sh' 
+
+echo "Building windows binary..."
+docker run --rm -e OS=windows -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash -x get.sh' 
+docker run --rm -e OS=windows -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash -x build.sh' 
+
+echo "Building mac binary..."
+docker run --rm -e OS=mac -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash -x get.sh' 
+docker run --rm -e OS=mac -v $(pwd):/code -it danielporto/ikemen-dev:latest bash -c 'cd /code && bash -x build.sh' 

--- a/get.sh
+++ b/get.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 export GOPATH=$PWD/go
+export CGO_ENABLED=1
+if [ -n "$OS" ];    then 
+    case "$OS" in
+    "windows")
+        export GOOS=windows
+        export CC=x86_64-w64-mingw32-gcc
+        export CXX=x86_64-w64-mingw32-g++
+        BINARY_NAME="Ikemen_GO.exe"; 
+
+        ;;
+    "mac") 
+        export GOOS=darwin
+        export CC=o64-clang 
+        export CXX=o64-clang++
+        BINARY_NAME="Ikemen_GO_mac"; 
+
+        ;;
+    "linux") 
+        BINARY_NAME="Ikemen_GO_linux"; 
+        ;;
+    esac 
+else 
+    BINARY_NAME="Ikemen_GO";  
+fi;
+
 go get -u github.com/yuin/gopher-lua
 go get -u github.com/go-gl/glfw/v3.2/glfw
 go get -u github.com/go-gl/gl/v2.1/gl


### PR DESCRIPTION
Added changes to build.sh and get.sh scripts to allow setting cross-compiling environment variables.
This variables are used by the docker-image ikemen-dev that set the compilers and build the binary for the respective target.

Look at the docker-build.sh file to see examples on how to use the image.
