### PR TITLE
fixed massive lag when moving from cell to cell

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -950,7 +950,7 @@ function start.f_resetGrid()
 			end
 		end
 	end
-	main.f_printTable(start.t_drawFace, 'debug/t_drawFace.txt')
+	--main.f_printTable(start.t_drawFace, 'debug/t_drawFace.txt')
 end
 
 --sets correct start cell


### PR DESCRIPTION
there should be no difference between cursor staying in the same position and moving - in both cases all slots are rendered. So yeah, something silly like this had to be responsible for the massive performance hit observed on larger rosters.